### PR TITLE
Implement FastAPI skeleton with auth, users, plants

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,15 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    JWT_SECRET: str = "secret"
+    JWT_ALG: str = "HS256"
+    ACCESS_EXPIRES: int = 15 * 60
+    REFRESH_EXPIRES: int = 7 * 24 * 60 * 60
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .routers import auth, users, plants
+
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth.router, prefix="/api/v1")
+app.include_router(users.router, prefix="/api/v1")
+app.include_router(plants.router, prefix="/api/v1")
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+
+@app.get("/version")
+async def version():
+    return {"version": "0.1.0"}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter
+from pydantic import BaseModel, EmailStr
+
+from ..services import auth_service
+
+
+class RegisterIn(BaseModel):
+    email: EmailStr
+    password: str
+    nickname: str
+
+
+class LoginIn(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class TokenRefreshIn(BaseModel):
+    refresh_token: str
+
+
+class LogoutIn(BaseModel):
+    refresh_token: str
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/register")
+async def register(data: RegisterIn):
+    return auth_service.register(data.email, data.password, data.nickname)
+
+
+@router.post("/login")
+async def login(data: LoginIn):
+    return auth_service.login(data.email, data.password)
+
+
+@router.post("/refresh")
+async def refresh(data: TokenRefreshIn):
+    return auth_service.refresh(data.refresh_token)
+
+
+@router.post("/logout")
+async def logout(data: LogoutIn):
+    auth_service.logout(data.refresh_token)
+    return {"success": True}

--- a/backend/app/routers/plants.py
+++ b/backend/app/routers/plants.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from typing import Optional
+
+from ..services import plants_service
+from ..utils.security import get_current_user
+
+
+class PlantCreateIn(BaseModel):
+    nickname: str
+    species_hint: Optional[str] = None
+    planted_at: Optional[str] = None
+    location: Optional[str] = None
+
+
+class PlantPatchIn(BaseModel):
+    nickname: Optional[str] = None
+    location: Optional[str] = None
+
+
+router = APIRouter(prefix="/plants", tags=["plants"])
+
+
+@router.post("")
+async def create_plant(data: PlantCreateIn, user=Depends(get_current_user)):
+    return plants_service.create(user["id"], data)
+
+
+@router.get("")
+async def list_plants(
+    limit: int = Query(10, gt=0),
+    cursor: Optional[str] = None,
+    user=Depends(get_current_user),
+):
+    return plants_service.list(user["id"], limit, cursor)
+
+
+@router.get("/{plant_id}")
+async def get_plant(plant_id: str, user=Depends(get_current_user)):
+    return plants_service.get(user["id"], plant_id)
+
+
+@router.patch("/{plant_id}")
+async def patch_plant(plant_id: str, data: PlantPatchIn, user=Depends(get_current_user)):
+    return plants_service.patch(user["id"], plant_id, data)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from ..services import users_service
+from ..utils.security import get_current_user
+
+
+class UserPatchIn(BaseModel):
+    nickname: str | None = None
+    avatar_url: str | None = None
+
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get("/me")
+async def get_me(user=Depends(get_current_user)):
+    return user
+
+
+@router.patch("/me")
+async def patch_me(data: UserPatchIn, user=Depends(get_current_user)):
+    return users_service.patch_me(user["id"], data.nickname, data.avatar_url)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,64 @@
+from ..config import settings
+from ..utils.errors import http_error
+from ..utils.security import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    hash_password,
+    verify_password,
+)
+from ..utils import token_blacklist
+from .storage import users, new_uuid, utcnow_iso
+
+
+def _user_public(user: dict) -> dict:
+    return {
+        "id": user["id"],
+        "email": user["email"],
+        "nickname": user["nickname"],
+        "avatar_url": user.get("avatar_url"),
+        "created_at": user["created_at"],
+    }
+
+
+def register(email: str, password: str, nickname: str) -> dict:
+    for u in users.values():
+        if u["email"] == email:
+            raise http_error("EMAIL_EXISTS", "email already registered", 400)
+    user_id = new_uuid()
+    user = {
+        "id": user_id,
+        "email": email,
+        "password": hash_password(password),
+        "nickname": nickname,
+        "avatar_url": None,
+        "created_at": utcnow_iso(),
+    }
+    users[user_id] = user
+    return _user_public(user)
+
+
+def login(email: str, password: str) -> dict:
+    user = next((u for u in users.values() if u["email"] == email), None)
+    if not user or not verify_password(password, user["password"]):
+        raise http_error("INVALID_CREDENTIALS", "invalid credentials", 401)
+    access = create_access_token({"sub": user["id"]}, settings.ACCESS_EXPIRES)
+    refresh = create_refresh_token({"sub": user["id"]}, settings.REFRESH_EXPIRES)
+    return {
+        "access_token": access,
+        "refresh_token": refresh,
+        "token_type": "bearer",
+        "user": _user_public(user),
+    }
+
+
+def refresh(refresh_token: str) -> dict:
+    payload = decode_token(refresh_token, refresh=True)
+    user_id = payload.get("sub")
+    access = create_access_token({"sub": user_id}, settings.ACCESS_EXPIRES)
+    return {"access_token": access, "token_type": "bearer"}
+
+
+def logout(refresh_token: str) -> None:
+    payload = decode_token(refresh_token, refresh=True)
+    token_blacklist.add(payload.get("jti"))

--- a/backend/app/services/plants_service.py
+++ b/backend/app/services/plants_service.py
@@ -1,0 +1,48 @@
+from typing import Any, Optional
+
+from ..utils.errors import http_error
+from ..utils.pagination import paginate
+from .storage import plants, new_uuid, utcnow_iso
+
+
+def create(user_id: str, data: Any) -> dict:
+    plant = {
+        "id": new_uuid(),
+        "user_id": user_id,
+        "nickname": data.nickname,
+        "species_hint": getattr(data, "species_hint", None),
+        "species": None,
+        "planted_at": getattr(data, "planted_at", None),
+        "location": getattr(data, "location", None),
+        "created_at": utcnow_iso(),
+    }
+    plants.append(plant)
+    return plant
+
+
+def list(user_id: str, limit: int, cursor: Optional[str]) -> dict:
+    user_plants = [p for p in plants if p["user_id"] == user_id]
+    slice_items, next_cursor, has_more = paginate(user_plants, limit, cursor, lambda x: x["id"])
+    return {"items": slice_items, "next_cursor": next_cursor, "has_more": has_more}
+
+
+def get(user_id: str, plant_id: str) -> dict:
+    for p in plants:
+        if p["id"] == plant_id and p["user_id"] == user_id:
+            return p
+    raise http_error("RESOURCE_NOT_FOUND", "plant not found", 404)
+
+
+def patch(user_id: str, plant_id: str, data: Any) -> dict:
+    plant = None
+    for p in plants:
+        if p["id"] == plant_id and p["user_id"] == user_id:
+            plant = p
+            break
+    if not plant:
+        raise http_error("RESOURCE_NOT_FOUND", "plant not found", 404)
+    if getattr(data, "nickname", None) is not None:
+        plant["nickname"] = data.nickname
+    if getattr(data, "location", None) is not None:
+        plant["location"] = data.location
+    return plant

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timezone
+import uuid
+
+users: dict[str, dict] = {}
+plants: list[dict] = []
+
+
+def new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/backend/app/services/users_service.py
+++ b/backend/app/services/users_service.py
@@ -1,0 +1,26 @@
+from .storage import users
+from ..utils.errors import http_error
+
+
+def get_me(user_id: str) -> dict:
+    user = users.get(user_id)
+    if not user:
+        raise http_error("RESOURCE_NOT_FOUND", "user not found", 404)
+    return {
+        "id": user["id"],
+        "email": user["email"],
+        "nickname": user["nickname"],
+        "avatar_url": user.get("avatar_url"),
+        "created_at": user["created_at"],
+    }
+
+
+def patch_me(user_id: str, nickname: str | None = None, avatar_url: str | None = None) -> dict:
+    user = users.get(user_id)
+    if not user:
+        raise http_error("RESOURCE_NOT_FOUND", "user not found", 404)
+    if nickname is not None:
+        user["nickname"] = nickname
+    if avatar_url is not None:
+        user["avatar_url"] = avatar_url
+    return get_me(user_id)

--- a/backend/app/utils/errors.py
+++ b/backend/app/utils/errors.py
@@ -1,0 +1,11 @@
+from fastapi import HTTPException
+
+from ..services.storage import new_uuid
+
+
+def http_error(code: str, message: str, status: int = 400) -> HTTPException:
+    trace_id = new_uuid()
+    return HTTPException(
+        status_code=status,
+        detail={"error": {"code": code, "message": message, "trace_id": trace_id}},
+    )

--- a/backend/app/utils/pagination.py
+++ b/backend/app/utils/pagination.py
@@ -1,0 +1,44 @@
+import base64
+import json
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+
+def encode_cursor(last_id: Optional[str], extra: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    if last_id is None and not extra:
+        return None
+    payload = {"last_id": last_id, "extra": extra or {}}
+    raw = json.dumps(payload).encode()
+    return base64.urlsafe_b64encode(raw).decode()
+
+
+def decode_cursor(cursor: Optional[str]) -> Dict[str, Any]:
+    if not cursor:
+        return {}
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode())
+        return json.loads(raw.decode())
+    except Exception:
+        return {}
+
+
+def paginate(
+    items: List[Any],
+    limit: int,
+    cursor_input: Optional[str],
+    id_getter: Callable[[Any], str],
+) -> Tuple[List[Any], Optional[str], bool]:
+    data = decode_cursor(cursor_input)
+    last_id = data.get("last_id")
+    start = 0
+    if last_id:
+        for idx, item in enumerate(items):
+            if id_getter(item) == last_id:
+                start = idx + 1
+                break
+    slice_items = items[start : start + limit + 1]
+    has_more = len(slice_items) > limit
+    slice_items = slice_items[:limit]
+    next_cursor = None
+    if has_more and slice_items:
+        next_cursor = encode_cursor(id_getter(slice_items[-1]), None)
+    return slice_items, next_cursor, has_more

--- a/backend/app/utils/security.py
+++ b/backend/app/utils/security.py
@@ -1,0 +1,69 @@
+from datetime import datetime, timedelta
+from typing import Any, Dict
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from ..config import settings
+from ..services.storage import new_uuid
+from .token_blacklist import contains
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+http_bearer = HTTPBearer(auto_error=False)
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return pwd_context.verify(password, hashed)
+
+
+def _create_token(data: Dict[str, Any], expires_seconds: int, token_type: str) -> str:
+    to_encode = data.copy()
+    to_encode.update(
+        {
+            "exp": datetime.utcnow() + timedelta(seconds=expires_seconds),
+            "jti": new_uuid(),
+            "token_type": token_type,
+        }
+    )
+    return jwt.encode(to_encode, settings.JWT_SECRET, algorithm=settings.JWT_ALG)
+
+
+def create_access_token(data: Dict[str, Any], expires_seconds: int) -> str:
+    return _create_token(data, expires_seconds, "access")
+
+
+def create_refresh_token(data: Dict[str, Any], expires_seconds: int) -> str:
+    return _create_token(data, expires_seconds, "refresh")
+
+
+def decode_token(token: str, *, refresh: bool = False) -> Dict[str, Any]:
+    try:
+        payload = jwt.decode(token, settings.JWT_SECRET, algorithms=[settings.JWT_ALG])
+        token_type = payload.get("token_type")
+        if refresh:
+            if token_type != "refresh" or contains(payload.get("jti")):
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        else:
+            if token_type != "access":
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        return payload
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(http_bearer),
+):
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    payload = decode_token(credentials.credentials)
+    from ..services import users_service
+
+    user_id = payload.get("sub")
+    return users_service.get_me(user_id)

--- a/backend/app/utils/token_blacklist.py
+++ b/backend/app/utils/token_blacklist.py
@@ -1,0 +1,11 @@
+_blacklist: set[str] = set()
+
+
+def add(jti: str) -> None:
+    _blacklist.add(jti)
+
+
+def contains(jti: str | None) -> bool:
+    if jti is None:
+        return False
+    return jti in _blacklist


### PR DESCRIPTION
## Summary
- add configuration, security utilities, in-memory storage, and pagination helpers for FastAPI
- implement auth, user, and plant services with JWT support and cursor-based pagination
- expose `/healthz` and `/version` along with auth, user, and plant API routes under `/api/v1`

## Testing
- `python -m py_compile $(find backend/app -name "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_68b9038c13d88324863b721efb31695f